### PR TITLE
Copy paste matrix parent inverse

### DIFF
--- a/src/blender_manifest.toml
+++ b/src/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "link_parents"
-version = "1.0.1-beta"
+version = "1.1.0-beta"
 name = "Link Parents"
 tagline = "Link objects parents & edit Parent Inverse Matrix in UI"
 maintainer = "Lukas Sabaliauskas <lukas_sabaliauskas@hotmail.com>"


### PR DESCRIPTION
Hello Lukas,

This PR adds copy/paste operators of matrix parent inverse to/from clipboard.
This allow to transfer matrix inverse on objects between blends.

In UI, buttons are added in panel header for easy access:
![image](https://github.com/user-attachments/assets/0ae5783b-e8a0-4c21-801e-60e63ac262ca)

Added a `bl_info` for compatibility with blender version before 4.2 (feel free to edit if you accept the PR)