### PR TITLE
Add copy-paste inverse_matrix for child-of constraints

### DIFF
--- a/src/blender_manifest.toml
+++ b/src/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "link_parents"
-version = "1.1.0-beta"
+version = "1.2.0-beta"
 name = "Link Parents"
 tagline = "Link objects parents & edit Parent Inverse Matrix in UI"
 maintainer = "Lukas Sabaliauskas <lukas_sabaliauskas@hotmail.com>"


### PR DESCRIPTION
Here is a new little PR:

### Add operators and panel to copy-paste inverse matrix of child-of constraints.

The panel appears in constraint properties when at least one child-of constraint exists on the active pose bone.
This can be useful when recreating constraints on prop after importing animation from another blend.


Same as last time, add only if you find it useful enough.

PS: I think you can remove the "beta" from the manifest version ;)